### PR TITLE
Fixed Jetty's DigestAuthenticator to MD5 for testing.

### DIFF
--- a/src/test/java/com/ning/http/client/async/AuthTimeoutTest.java
+++ b/src/test/java/com/ning/http/client/async/AuthTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2010-2012 Sonatype, Inc. All rights reserved.
  *
@@ -84,7 +84,9 @@ public abstract class AuthTimeoutTest extends AbstractBasicTest {
         if (auth != null && auth.equals("BASIC")) {
             authenticator = new BasicAuthenticator();
         } else if (auth != null && auth.equals("DIGEST")) {
-            authenticator = new DigestAuthenticator();
+            final DigestAuthenticator digestAuthenticator = new DigestAuthenticator();
+            digestAuthenticator.setAlgorithm("MD5");
+            authenticator = digestAuthenticator;
         } else {
             authenticator = new BasicAuthenticator();
         }

--- a/src/test/java/com/ning/http/client/async/BasicAuthTest.java
+++ b/src/test/java/com/ning/http/client/async/BasicAuthTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2010 Ning, Inc.
  *
@@ -161,7 +161,9 @@ public abstract class BasicAuthTest extends AbstractBasicTest {
             }
         };
         _securityHandler.put("/*", Constraint.from("DIGEST", Constraint.Authorization.SPECIFIC_ROLE, user, admin));
-        _securityHandler.setAuthenticator(new DigestAuthenticator());
+        final DigestAuthenticator digestAuthenticator = new DigestAuthenticator();
+        digestAuthenticator.setAlgorithm("MD5");
+        _securityHandler.setAuthenticator(digestAuthenticator);
         _securityHandler.setLoginService(loginService);
         _securityHandler.setHandler(new RedirectHandler());
 

--- a/src/test/java/com/ning/http/client/async/DigestAuthTest.java
+++ b/src/test/java/com/ning/http/client/async/DigestAuthTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2010-2012 Sonatype, Inc. All rights reserved.
  *
@@ -73,7 +73,9 @@ public abstract class DigestAuthTest extends AbstractBasicTest {
 
         final SecurityHandler.PathMapped _securityHandler = new SecurityHandler.PathMapped();
         _securityHandler.put("/*", Constraint.from("BASIC", Constraint.Authorization.SPECIFIC_ROLE, user, admin));
-        _securityHandler.setAuthenticator(new DigestAuthenticator());
+        final DigestAuthenticator digestAuthenticator = new DigestAuthenticator();
+        digestAuthenticator.setAlgorithm("MD5");
+        _securityHandler.setAuthenticator(digestAuthenticator);
         _securityHandler.setLoginService(loginService);
         _securityHandler.setHandler(configureHandler());
         server.setHandler(_securityHandler);


### PR DESCRIPTION
- See https://github.com/eclipse-ee4j/glassfish-grizzly-ahc/pull/166#issuecomment-4659455974