### PR TITLE
Fixed/cleaned up errors in the "maven-javadoc-plugin" pom within reporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,25 +312,15 @@
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.12.0</version>
                 <configuration>
+                    <doclint>-missing</doclint>
                     <release>${maven.compiler.release}</release>
                     <encoding>UTF-8</encoding>
                     <maxmemory>1g</maxmemory>
-                    <doclet>com.google.doclava.Doclava</doclet>
-                    <useStandardDocletOptions>false</useStandardDocletOptions>
                     <additionalJOption>-J-Xmx1024m</additionalJOption>
-                    <docletArtifact>
-                        <groupId>com.google.doclava</groupId>
-                        <artifactId>doclava</artifactId>
-                        <version>1.0.3</version>
-                    </docletArtifact>
                     <additionalOptions>
-                        <additionalOption>
-                            -hdf project.name "${project.name} ${project.version}"
-                        </additionalOption>
                         <additionalOption>
                             -d ${project.reporting.outputDirectory}/apidocs
                         </additionalOption>
@@ -346,7 +336,6 @@
                 </reportSets>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <version>${surefire.version}</version>
             </plugin>


### PR DESCRIPTION

> mvn site -DskipTests

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.7.1:site (default-site) on project grizzly-http-client: Error generating maven-javadoc-plugin:3.12.0:javadoc report:
[ERROR] Exit code: 1
[ERROR] error: Class com.google.doclava.Doclava is not a valid doclet.
[ERROR]   Note: As of JDK 13, the com.sun.javadoc API is no longer supported.

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.7.1:site (default-site) on project grizzly-http-client: Error generating maven-javadoc-plugin:3.12.0:javadoc report:
[ERROR] Exit code: 1
[ERROR] error: invalid flag: -hdf
[ERROR] 1 error
```

PS) This is something I confirmed while looking at https://github.com/eclipse-ee4j/glassfish-grizzly-ahc/pull/164